### PR TITLE
Fix for footer display problem in IE11

### DIFF
--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -1,0 +1,51 @@
+@charset "utf-8";
+
+// Define defaults for each variable.
+
+$base-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !default;
+$base-font-size:   16px !default;
+$base-font-weight: 400 !default;
+$small-font-size:  $base-font-size * 0.875 !default;
+$base-line-height: 1.5 !default;
+
+$spacing-unit:     30px !default;
+
+$text-color:       #111 !default;
+$background-color: #fdfdfd !default;
+$brand-color:      #2a7ae2 !default;
+
+$grey-color:       #828282 !default;
+$grey-color-light: lighten($grey-color, 40%) !default;
+$grey-color-dark:  darken($grey-color, 25%) !default;
+
+$table-text-align: left !default;
+
+// Width of the content area
+$content-width:    800px !default;
+
+$on-palm:          600px !default;
+$on-laptop:        800px !default;
+
+// Use media queries like this:
+// @include media-query($on-palm) {
+//   .wrapper {
+//     padding-right: $spacing-unit / 2;
+//     padding-left: $spacing-unit / 2;
+//   }
+// }
+@mixin media-query($device) {
+  @media screen and (max-width: $device) {
+    @content;
+  }
+}
+
+@mixin relative-font-size($ratio) {
+  font-size: $base-font-size * $ratio;
+}
+
+// Import partials.
+@import
+  "minima/base",
+  "minima/layout",
+  "minima/syntax-highlighting"
+;

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -177,7 +177,9 @@
  */
 .page-content {
   padding: $spacing-unit 0;
-  flex: 1;
+  // Update to fix for IE11 as per https://github.com/jekyll/minima/issues/247
+  // flex: 1;
+  flex: 1 0 auto;
 }
 
 .page-heading {


### PR DESCRIPTION
* Import sass files from theme gem
  * ~/_sass/minima/_layout.scss
  * ~/_sass/minima/minima.scss
  * Need the file you're overwriting AND the theme's main scss file that pulls in all the parts
* Update flex for .page-content

NB:
There are a good few files lying around that you don't need, which I assume is due to your ongoing work on this issue. I can help you tidy up if you like!

NB:
If you work on a new branch for each unit of work you do, then the `master` branch will stay tidy, and hence it will be easier for others to understand what you've been doing.

NB:
You don't have a way of testing your changes live using this setup. There are a few options for making a live testing environment -- just shout if you want to chat.